### PR TITLE
replaced deprecated functions to use stdlib v9.7.0

### DIFF
--- a/manifests/audisp/plugin.pp
+++ b/manifests/audisp/plugin.pp
@@ -7,18 +7,20 @@ define auditd::audisp::plugin (
   $format     = 'string',
   $audisp_dir = $auditd::params::audisp_dir
 ) {
-  validate_bool($active)
-  validate_re($direction, '^(out|in)$',
-  "${direction} is not supported for 'direction'. Allowed values are 'out' and 'in'.")
-  validate_string($path)
-  validate_re($type, '^(builtin|always)$',
-  "${type} is not supported for 'type'. Allowed values are 'builtin' and 'always'.")
-  if $args {
-    validate_string($args)
+  assert_type(Boolean,$active)
+  if $direction !~ '^(out|in)$' {
+    fail("${direction} is not supported for 'direction'. Allowed values are 'out' and 'in'.")
   }
-  validate_re($format, '^(binary|string)$',
-  "${format} is not supported for 'format'. Allowed values are 'binary' and 'string'.")
-
+  assert_type(String, $path)
+  if $type !~ '^(builtin|always)$' {
+    fail("${type} is not supported for 'type'. Allowed values are 'builtin' and 'always'.")
+  }
+  if $args {
+    assert_type(String,$args)
+  }
+  if $format !~ '^(binary|string)$' {
+    fail("${format} is not supported for 'format'. Allowed values are 'binary' and 'string'.")
+  }
   if $active == true {
     $real_active = 'yes'
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -400,20 +400,20 @@ class auditd (
 ) inherits auditd::params {
   # Validate all special variables
 
-  validate_absolute_path($log_file)
+  assert_type(Stdlib::Absolutepath, $log_file)
 
   if $disp_qos != undef {
-    validate_absolute_path($dispatcher)
+    assert_type(Stdlib::Absolutepath, $dispatcher)
   }
   # check if email address is valid
   if $action_mail_acct !~ /^\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$/ {
     fail("Parameter error: E-Mail address \"${action_mail_acct}\" is not valid.")
   }
   if $tcp_client_ports != undef {
-    validate_absolute_path($krb5_key_file)
+    assert_type(Stdlib::Absolutepath, $krb5_key_file)
   }
 
-  validate_absolute_path($rules_file)
+  assert_type(Stdlib::Absolutepath, $rules_file)
 
   # Install package
   package { $package_name:

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -9,10 +9,10 @@ define auditd::rule ($content='', $order=10) {
     $body = $content
   }
 
-  if (!is_numeric($order) and !is_string($order)) {
+  if ($order !~ Integer and $order !~ String) {
     fail('$order must be a string or an integer')
   }
-  validate_string($body)
+  assert_type(String,$body)
 
   concat::fragment { "auditd_fragment_${name}":
     target  => $auditd::rules_file,


### PR DESCRIPTION
Replaced stdlib functions validate_absolute_path
with assert_type(Stdlib::Absolutepath, path)
for stdlib v9.7.0. Analogously repacled other
validate_* functions with assert_type.

Replaced is_numeric, validate_re with
a match expression.