### PR TITLE
Ignore errors and generate rules for auditd

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,26 @@ Determines if `auditd` will continue to load rules if it encounters any errors.
 
 Default: `false`
 
+#### `ignore_errors`
+
+When  given by itself, ignore errors when reading rules from a file. This causes auditctl to always return a success exit code.
+
+Default: `false`
+
+#### `generate_rules`
+
+Generate audit.rules file from directory.
+You can notify this exec from yours resources
+Example:
+```
+file { '/etc/audit/rules.d/my.rules':
+  source => 'puppet:///modules/mymodule/my.rules',
+  notify => Exec['generate_rules']
+}
+```
+
+Default: `false`
+
 #### `audisp_q_depth`
 
 This is a numeric value that tells how big to make the internal queue of the audit event dispatcher. A bigger queue lets it handle a flood of events better, but could hold events that are not processed when the daemon is terminated. If you get messages in syslog about events getting dropped, increase this value.

--- a/README.md
+++ b/README.md
@@ -481,8 +481,11 @@ You can notify this exec from yours resources
 Example:
 ```
 file { '/etc/audit/rules.d/my.rules':
+  ensure => file,
+  owner  => 'root',
+  mode   => '0640',
   source => 'puppet:///modules/mymodule/my.rules',
-  notify => Exec['generate_rules']
+  notify => Exec['generate_rules'],
 }
 ```
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -319,6 +319,10 @@
 # [*continue_loading*]
 #   Wether or not parsing the rules should stop when an error occurs.
 #
+# [*ignore_errors*]
+#   When  given by itself, ignore errors when reading rules from a file. This causes auditctl to always return a success exit code. If passed as an argument to -s then it gives an interpretation of the numbers to human readable
+#              words if possible.
+#
 # === Examples
 #
 #  class { 'auditd':
@@ -371,6 +375,7 @@ class auditd (
   String $krb5_principal                                                             = 'auditd',
   Optional[String] $krb5_key_file                                                    = undef,
   Boolean $continue_loading                                                          = false,
+  Boolean $ignore_errors                                                             = false,
 
   # Variables for Audit files
   String $rules_file                    = $auditd::params::rules_file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -323,6 +323,9 @@
 #   When  given by itself, ignore errors when reading rules from a file. This causes auditctl to always return a success exit code. If passed as an argument to -s then it gives an interpretation of the numbers to human readable
 #              words if possible.
 #
+# [*generate_rules*]
+#   Generate rules from files.
+#
 # === Examples
 #
 #  class { 'auditd':
@@ -376,6 +379,7 @@ class auditd (
   Optional[String] $krb5_key_file                                                    = undef,
   Boolean $continue_loading                                                          = false,
   Boolean $ignore_errors                                                             = false,
+  Boolean $generate_rules                                                            = false,
 
   # Variables for Audit files
   String $rules_file                    = $auditd::params::rules_file,
@@ -487,7 +491,11 @@ class auditd (
   # Manage the service
   if $manage_service {
     if $facts['os']['family'] =~ 'RedHat' {
-      $redhat_args = { 'restart' => 'service auditd restart',  'start' => 'service auditd start', 'status' => 'service auditd status', 'stop' => 'service auditd stop'}
+      $redhat_args = {
+        'restart' => 'service auditd restart',
+        'start'   => 'service auditd start',
+        'status'  => 'service auditd status',
+        'stop'    => 'service auditd stop'}
     }
     else {
       $redhat_args = {}
@@ -520,5 +528,15 @@ class auditd (
           ],
         }
     }
+  }
+  if $generate_rules {
+      exec { 'generate_rules':
+        command     => 'augenrules --load',
+        path        => ['/sbin','/bin','/usr/sbin','/usr/bin'],
+        refreshonly => true,
+        subscribe   => [
+          Concat[$rules_file],
+        ],
+      }
   }
 }

--- a/templates/audit.rules.begin.fragment.erb
+++ b/templates/audit.rules.begin.fragment.erb
@@ -1,7 +1,12 @@
 # Default Rule - Delete ALL
 -D
 
-# Set Buffer size - increase for Busy Systems
+<% if @ignore_errors == true -%>
+# Ignore errors.
+-i
+<% end -%>
+
+# Set Buffer size - increase for Busy Systems.
 -b <%= @buffer_size %>
 
 <% if @continue_loading == true -%>


### PR DESCRIPTION
Add two parameters:
- ignore_errors - ignore errors while loading rules
- generate_rules - generate rules from rules.d directory
