### PR TITLE
Fix missing package audispd-plugins on syslog plug-in installation and some minor cleanup

### DIFF
--- a/manifests/audisp/af_unix.pp
+++ b/manifests/audisp/af_unix.pp
@@ -6,6 +6,6 @@ class auditd::audisp::af_unix (
     path    => 'builtin_af_unix',
     type    => 'builtin',
     args    => $args,
-    require => Package['auditd'],
+    require => Package[$auditd::params::audisp_package],
   }
 }

--- a/manifests/audisp/au_remote.pp
+++ b/manifests/audisp/au_remote.pp
@@ -1,9 +1,5 @@
 class auditd::audisp::au_remote {
-  if ! defined(Package[$auditd::params::audisp_package]) {
-    package { $auditd::params::audisp_package:
-      ensure => 'present',
-    }
-  }
+  stdlib::ensure_packages($auditd::params::audisp_package)
 
   auditd::audisp::plugin { 'au-remote':
     path    => '/sbin/audisp-remote',

--- a/manifests/audisp/audispd_zos_remote.pp
+++ b/manifests/audisp/audispd_zos_remote.pp
@@ -1,9 +1,5 @@
 class auditd::audisp::audispd_zos_remote {
-  if ! defined(Package[$auditd::params::audisp_package]) {
-    package { $auditd::params::audisp_package:
-      ensure => 'present',
-    }
-  }
+  stdlib::ensure_packages($auditd::params::audisp_package)
 
   auditd::audisp::plugin { 'audispd-zos-remote':
     path    => '/sbin/audispd-zos-remote',

--- a/manifests/audisp/syslog.pp
+++ b/manifests/audisp/syslog.pp
@@ -4,10 +4,13 @@ class auditd::audisp::syslog (
   $args = 'LOG_INFO',
 
 ) {
+
+  stdlib::ensure_packages($auditd::params::audisp_package)
+
   auditd::audisp::plugin { 'syslog':
     path    => $path,
     type    => $type,
     args    => $args,
-    require => Package['auditd'],
+    require => Package[$auditd::params::audisp_package],
   }
 }

--- a/manifests/audisp/syslog.pp
+++ b/manifests/audisp/syslog.pp
@@ -5,12 +5,12 @@ class auditd::audisp::syslog (
 
 ) {
 
-  stdlib::ensure_packages($auditd::params::audisp_package)
+  stdlib::ensure_packages($auditd::audisp_package)
 
   auditd::audisp::plugin { 'syslog':
     path    => $path,
     type    => $type,
     args    => $args,
-    require => Package[$auditd::params::audisp_package],
+    require => Package[$auditd::audisp_package],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -493,27 +493,5 @@ class auditd (
       hasstatus => true,
       *         => $redhat_args,
     }
-
-    if $service_provider == 'systemd' and $facts['os']['family'] !~ 'RedHat' {
-        exec { 'reload_auditd':
-          command     => "systemctl reload ${service_name}",
-          path        => ['/sbin','/bin','/usr/sbin','/usr/bin'],
-          refreshonly => true,
-          subscribe   => [
-            File['/etc/audit/auditd.conf'],
-            Concat[$rules_file],
-          ],
-        }
-    }
-    else {
-        exec { 'reload_auditd':
-          command     => "/sbin/service ${service_name} reload",
-          refreshonly => true,
-          subscribe   => [
-            File['/etc/audit/auditd.conf'],
-            Concat[$rules_file],
-          ],
-        }
-    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "pseiler-auditd",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "author": "Danny Roberts, Philipp Seiler",
   "summary": "Manage the audit daemon and it's rules.",
   "license": "BSD-2-Clause",

--- a/spec/classes/auditd_spec.rb
+++ b/spec/classes/auditd_spec.rb
@@ -46,7 +46,6 @@ describe 'auditd' do
 
     it { is_expected.to compile.with_all_deps }
     it { is_expected.not_to contain_service('auditd') }
-    it { is_expected.not_to contain_exec('reload_auditd') }
   end
 
   context "Check if 'manage_service = true' is acting correctly" do
@@ -69,7 +68,6 @@ describe 'auditd' do
 
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_service('auditd') }
-    it { is_expected.to contain_exec('reload_auditd')
       .with_command('/sbin/service auditd reload')
       .with_subscribe('[File[/etc/audit/auditd.conf]{:path=>"/etc/audit/auditd.conf"}, Concat[/etc/audit/rules.d/puppet.rules]{:name=>"/etc/audit/rules.d/puppet.rules"}]')
     }
@@ -96,7 +94,6 @@ describe 'auditd' do
 
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_service('auditd') }
-    it { is_expected.to contain_exec('reload_auditd')
       .with_command('systemctl reload auditd')
       .with_subscribe('[File[/etc/audit/auditd.conf]{:path=>"/etc/audit/auditd.conf"}, Concat[/etc/audit/rules.d/puppet.rules]{:name=>"/etc/audit/rules.d/puppet.rules"}]')
     }


### PR DESCRIPTION
1. Use stdlib::ensure_packages for
$auditd::params::audisp_package
and require it for plugins.
It could happen that audispd-plugins
was not installed even though syslog
plugin was configured.
2. removed obsolete unused exec reload_auditd
3. removed ::params namespace for package install
4. version bump